### PR TITLE
Add client portal agreement PDF and development config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mise dev:*)",
+      "Bash(mise build:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mise dev:*)",
+      "Bash(mise build:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create *)"
+    ]
+  }
+}

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,10 @@
+[tools]
+hugo = "0.104.1"
+
+[tasks.dev]
+description = "Run Hugo development server with drafts"
+run = "hugo server -D"
+
+[tasks.build]
+description = "Build Hugo site with minification"
+run = "hugo --minify"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Hugo static site for Folsom Lake Accounting, a CPA business website. The site uses the Graysx theme (a fork of StartBootstrap Grayscale).
+
+## Commands
+
+**Local development:**
+```bash
+mise run dev
+```
+
+**Production build:**
+```bash
+mise run build
+```
+
+## Architecture
+
+- **config.toml**: Site configuration including business info (address, phone, email), navigation menu, and theme settings
+- **data/homepage.yml**: All homepage content (hero section, about text, service cards) - this is where most content edits happen
+- **themes/graysx/**: The Graysx Hugo theme
+  - `layouts/index.html`: Main homepage template
+  - `layouts/partials/`: Header, footer, and head partials
+- **static/assets/**: Images and static files
+
+## Deployment
+
+- CI runs on pull requests (`.github/workflows/ci.yml`) - builds with Hugo to verify no errors
+- Pushes to `main` auto-deploy to GitHub Pages (`.github/workflows/publish.yml`)
+- Hugo version: 0.104.1 (extended), managed locally via mise

--- a/static/client-portal-agreement.pdf
+++ b/static/client-portal-agreement.pdf
@@ -1,0 +1,112 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260115004359+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260115004359+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1906
+>>
+stream
+Gat=+bAQ>u']%q&ma>$Y<*Oes75rJu*HZg7o\ipeaG,gjRuKh9,ScC;of\Y9??Tcg!Wt_ZOh?`rm^_DKB)'WghlJ+"YbCMMc=rluAkV`,ZD>`XqK6lNn'*tt>i-kWh9OI0%N@)d$hJOcK<=b5Zo)\mS<VHLbpT>:T/0j2-L9D#T/Sc)IP-l7SpiWLMh:A@<lu$gmqD;'D8)e>UXa>B&,]2X=>0,H2b)@7o45fMb_,d9TGc'lWV)Q(S%Wk7M@]>5nU!h<BtENj0N^NO,A\hu0'Vms6KdthrBX%M_<VYN1c5#A$>3!-/=n-CB:5a,=*b\7oaYu?PMY(bA]nbDO6>aePrd&+Du8(Eqbu>_`^`rd"(U)jD,*_P`7mel1XFKa8%aLCQ:^8\Rl:'U2I8I:Ap`NiP?Da6lUhm)2^Q[NN/Jo\ei^!<ZKp)k]DW,*fnciHQr9NP@WE5e"=AlM3qistdb2*-Z6Ar_F(6t$kkEe3`lZEEY?#k6O'f%.c4)"5p]mfV)/PMsqLjXjN`h1[XiOJ8]^R\(O#`P\be,f:A`Tu?DC[=!PFJXc8DOP6V74I1_CMBCOojq]X."TRh$W$Mb3oT'AJ.0Uh&G<9SY:\@:V8cm1JbP4'K@t#r[]s>iG#f0V:&[bjpYLlbii]=Yp,AV>;6H3b41al[.4*7nD?h7N,p2h.uBL(hI0u-Cei7p.sB#'d<Sl$@G#>b-AJ?'f>"E"L`t04CLgYPhbLTj7hdS?juiOiL&`b*S=2s((fVqs.J"d(8Eb!;(6F&WeT.Ggc&!Gj1%Sl?5t7Q/PjO1]a[kf]iWu343qG<a^g*0_W%<0%9?o%pHT;Y5-=NIA?lrt6>%e0QBO$E>PpTSej-3g9.\K#&>e)bC.3#YBH)n_ZNZn\G%^Uh.OYlTNk/PUX5-4FWPZLD]>eZ%?MhM'2<>??ks"%+m*a&K'QYe>*bKI=p5J0ILpTnCRGFP`iFVkD65nugZNg7I!/KP;@c5(!U"/7*;+NT*Npc)kTbh.u`2[>1+Sb?gIP\1r`/6E*+'u3meLo[/S/?Le^B1h8*OI:iT[^N>d(dS15qqi0H(hUP`\7JLpNTB&sTTSUZ*NhQo0^Yf8)MSh4ZmE5not34rZ9Zok)2r>_C9Z$as1m1nin]g(1DiRF1sf#<PEt^p7GOXF,BAW'(S/uoI(UR]ilosq\<7D)c"4<g28T=<>\0%?Y-u?l5l=<Ub)]`F'bW/8laMt#aWuU5?R9U$^/?5['6eILqr"NM8iVTLPeT^,4]p+l`/<lT>?$4+JD-!O7,/ENVoPoXTF(SJOuXq(p8#s,OSMX0q:Fc12b2^.a@8;s^i^uI[D5s!)_[l)+D1ju9AH;2Fr-CQQgBpY"P+H8)2S2o(`=5IEhu1OA>8%Gj.a\R3p/u[ZjQn)&\tQmjHQ73XS>`C46&/UoiB$fVkY#5R,*eSS(bV*$?Xq\((t%A?*rQs@:QnDk/YK'NN7^rRiO2=\*k[C31rLjHMdu<SZf2\_ZdW#6C4[O!eLNm#%GY:b=PKP`Mdr]E0^^)Es3kg"(]+3TM5NEa9X2E1BiT_-3$Y1j%]S07<d5g1^sD*(:Z/(;\T9-:<ipd-]P<$f>GNi]UKCGUZINc.&Z49JO2%/bT42UN+=U:+r5"f0q:;\2OO37`5XcJ6dEZ:':e16Bi3%2?\ke[Bg9MuU,:#MT-o_0>SGiW;*^kd#P@aa^-Di"GX:u*0Qisn\[T8re2>qaDPg$ap*T?a.<-G'?FG);Hh.@7;og+rQ62e*=>^W&MbfT$/Ts<O35>$bi)3%FWe4,>N6G/A_<noKI;9V3+9PcZ0f7Mt]I@XZ,=mHFK;J_d1MS=iVE9\'+u+CJMB%ZTZjgsB!`*a^]t>#Wc2!QEE/P-KT9>i4040/0#MVaIRt)/okiRAT`D_!~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1924
+>>
+stream
+GauHLgQ(#H&:Ml+bbJ*]*D:bJS"!&J+9g33GpomMZp`#P-rM4bFks7i),`D+0*8RIZ+sg#%qgX[ba]Pf6>QKEiHJ<7rN`7Y*th1Dg(ooXX=e2`Okt"`I=IN(Q<2\=Pceo-<]<!gk;\S4:6Oqn-#G0&jE&/dR\(;1@SO#$Kuc%64WRM.=,(&1p+I8[KAiQX4"9E3EIRYNG-+i#X`JLSSa#?Z6+.m`1TBf-.HtMM7gGr\7N+DghFc\,kYKr2CNAZe,>:kW?8N?p#l_7sd397DfS4R412@6Y.[cLie4<Xi,8trE9qsNMke]n(L1DV"YWF$IAITC"<X9l5"!4T@!5S%6r;;B0eP2*5&'cVk=,^[?-F.X/QnGOCoMM#p8C,_-Y?ZPM8\!nR?W89K9Z2&OI)PV%dPh=i;RtH>;K&t+VP-f:2*t4fNdUXlJ48:,e:`eGOO6A^4=<SK!B(I3JGKUE9.s'LUQoe]5f:B0+Dh,M/ko7di]4%g1)[hMjnTmOW3,T)V^3'9Sn*2D]O]#d-aFur\d*"[VmL4.agrXeQS?6C/h1:iiD-%0,WA*Pj_ai,.W8A[ak=A].B]qZ?Htr!T:t`5nk&\f$Ui*r`DD,a2K8.1Vi2SP]ert5MH3[3]%Y"8cTs@:<M<Os0Bf1T[Q6os<hbi%!Q\Mk!>5D#]l^m;jjG]4K;o^04VBV38%03G-,@)'!a-@$$5F2qkENg-G^bGcrPW#,\YXfl<-@uBj>q.;BUc\Xl5sp6-q%m+E&E#^$_KhSAD#NX*1JG\XLbRt?n)j/4pe>/Ug3VYL2oZfBZF?iX^>$q[k%;lP05rK1MqR+Ar>j4o&;lJ60LFsJ34%#-\t#NNF[-b47_bp>Le6MEa..!AH<S]R9u\.b>sC>pn21IoRM&N/:.]b;fXmd$7LOg:>Y"iL_bm0TTDXfWnhV]"ki_..Mi6cTpUdq9]HkD(MF4$'@J&9e#J?EcB*:5?G2"[!8LZ2k?c/1TbMU2Hh+MeXNQ#_l*K_+mJ0H$Y@\'3;[`6WO-5BO(\E0D[e=+ED9Ze#C2-JRc!'6XjuTUN@!f(tE"T]j^`7gX>$JgMm>bVr@KiuQ\UW7fdh[_.*:`i8Lui.a7GOD#&u-dFNN)<"k]F#H'DaXmbXKmr`/=5Z>8_'Jfa9+Rna^BO6EpV&0-)\RT!UB:)/g5M)sa/`1PKqb?9c#0orRg*<r0ml[@)t5k%0)'k=8ROG:/%aXS^"2j_]`"'@`U_,[@[jb1V*K:6Uo`44'^d(_f7G*Nr(I,)D#fdLj)B3chT*JA%t.TSom;j9bH02/iX,R$8Gk>CGj\M"r_h;)DSA58Hk[4R=Gq)#&kl`m#$!LPToDJm(-<4,&*E8"l@e(F0RB#G3fJVUmJap`s"IY1G6l6QW=H6UTZ]I[@SPGI`)!I,O(BIJr_[IU?^pGRAMUGF]OnBG7a;,S_JV.)ZSAdt[7WUY#`POF>cbICng`)4"9prA[o#^oi%u8e,%?PWX=ZfMp9b[gd0o2CB<kA`LJKU,r@]fk`]?:5XH;'9jdBAdob:#R'nP3LTL7$12_g^c-tXP[hd$*Su]j:Yj%6Qeb6l\3)floNc*<'sZ'*UZ^T'Kp7s1h&8?X*:k&oYpEt.iQ;arBP6-?cD:n@*]>^g`8dFnnd`_+bqL#j.)Sl72b`.tRS@,^RZaJI'7T^+^P3'?Fn/BLAtl/`b?r#L4BJc%`EqtjF*p-TqL0W""5(d1Eu(48*6eN4:77WY(?9iB\!$-9NpCDb34W(2krfII2->c6Or'O,O@t&uc+)go^]#9:d9AG>@C<P!n.fkPr<iJ!iM+AJ[mDT=7\dmqXk_.%*<!VW*o/7eap)O894*@<9*d1m^2^:!_s9k5".CkY2p8*O0OQVAA/S.pQKt7Z/rrZ*.0+=.ArAIT6'Eg_WEMN6rM*Ho!g]fL8H~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1024
+>>
+stream
+Gat=)9lo&I&A@sBm*X(VW[Q&R4$>kTjC$-6J=mq/oE(5<KT&GO!#1Lcla*61[WS#ebtoX9!;>f,D\l4M'7>E2]4q>3!e+>W&55Bk+de7%+C_#'io<IHgc8`#Vm)Q4a#=ico94X[Cb@Cu(sqCf)FU$cOD[2+AT0M]8D@l,Fe]@eCUf_NaOY':s+"31g.A3Sf!!"q53e\^cbG#*!9/uNnID0m9]hQ'pR0ef`n)kS:tERG]s+)gGY;JaGQJ3IP896lE)/G@WH]6\I@kRa'Td<B8KKZ+NI]J^_BYB'Jr_Hr=E9.C:BW>m*FU[*ZImM"aIMg$`Y4Mi'XC^\'d?U,+O@P?nbDE!@)[Y_oB_K+1kI7^P/:STknPXd!tJqI,R#\0+R:`pnt%.=K![t-7<ub'^sM0F`8l@M-`mJq`/65q/1H+fnOY^8`<]Qa`apgpW;Ia<?:I8,p_I4t8s*;!6N)$^T$/#B.D#E[QRaC\micuW"EM?_$d4p10."rNK)RFsV\G=>1m[O#+nIN(YbVgdZAe$@Wq6<L7#]SkN$-?mK"``IQ]\coLR'-0*#CUEqoOfsm<P*T_<r^>,U'WFQuH)N0="K#nVGM*9LRbA)*DFULU-\EH,&7Jf8J<X*MOGJVG%)tXo!Zeqa5EOg%<LF]aDK%::AjXfbgP(eN,CaOh.rn>>XXnWZ4-<ohN>EG5u=kaFi5j7XnGr\.0!LJ_MX[GM3;bST/\*$?0aV;+2^b'7T2+C(taodo^6>U<BQ7ep=F$E'WE'q[<u'P7]ok\+Pm_[lZRJUegDqHF5LRCceOFFf%p?hf!tD:=j!KGdX4iK6Lr@?(ItBm.s4fKJ215oo`Ylo8h$W.Fn-M^&?fYUSUFsUoALKq(JApH8*Sbp<$K;/),Ec2]A6hnQJ.ZMg]9Pd6gBNo@]4dh5a/OFTqL.p]8"HpV=O'f,Z&E7>=3)=6oPN#`7qmZGHZi@,+r[Gu_J=S!V3eEmF]Wi!66N+4Rpjb`HRX]!^hfUKFS@-Ys1f\hE"$$YOV\2u~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000527 00000 n 
+0000000721 00000 n 
+0000000915 00000 n 
+0000000983 00000 n 
+0000001266 00000 n 
+0000001337 00000 n 
+0000003335 00000 n 
+0000005351 00000 n 
+trailer
+<<
+/ID 
+[<b1504e70fdb9caf2f05b4cb5f69a9d33><b1504e70fdb9caf2f05b4cb5f69a9d33>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
+>>
+startxref
+6467
+%%EOF


### PR DESCRIPTION
## Summary
- Add client portal agreement PDF available at `/client-portal-agreement.pdf`
- Add mise.toml for local Hugo version management (0.104.1)
- Add CLAUDE.md for AI assistant guidance

## Test plan
- [ ] Verify PDF is accessible at https://folsomlakeaccounting.com/client-portal-agreement.pdf after deploy
- [ ] Verify `mise run dev` works locally

🤖 Generated with [Claude Code](https://claude.ai/code)